### PR TITLE
Update for docker-registry 0.9.0

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.0.8"
+version           "0.0.9"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 
@@ -17,6 +17,7 @@ end
 end
 
 depends 'application', '>= 3.0.0'
+depends 'python'
 
 attribute "docker-registry/repository",
   :display_name => "Docker Registry Git Repo",

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.0.7"
+version           "0.0.8"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,11 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.0.6"
+version           "0.0.7"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 
-# TODO: debian centos redhat amazon scientific oracle fedora 
+# TODO: debian centos redhat amazon scientific oracle fedora
 %w{ ubuntu smartos }.each do |os|
   supports os
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.1.3"
+version           "0.1.4"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.0.9"
+version           "0.0.10"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.1.2"
+version           "0.1.3"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.1.5"
+version           "0.1.6"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.1.0"
+version           "0.1.1"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.0.10"
+version           "0.1.0"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.1.1"
+version           "0.1.2"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Raul E Rangel"
 maintainer_email  "Raul.Rangel@Disney.com.com"
 license           "Apache 2.0"
 description       "Installs and configures docker-registry"
-version           "0.1.4"
+version           "0.1.5"
 
 recipe "docker-registry", "Installs the docker-registry and sets up configuration"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -149,7 +149,7 @@ application "docker-registry" do
     port node['docker-registry']['internal_port']
     workers node['docker-registry']['workers']
     worker_class "gevent"
-    app_module "wsgi:application"
+    app_module "docker_registry.wsgi:application"
     requirements "requirements/main.txt"
     virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
     environment :SETTINGS_FLAVOR => node['docker-registry']['flavor']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -129,6 +129,7 @@ application "docker-registry" do
     for package in [
       node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
       node['docker-registry']['install_dir'],
+      'file://' + node['docker-registry']['install_dir'] + '#egg=docker-registry[bugsnag,newrelic,cors]'
     ] do
 
       python_pip "#{package}" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -129,7 +129,7 @@ application "docker-registry" do
     for package in [
       node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
       node['docker-registry']['install_dir'],
-      'file://' + node['docker-registry']['install_dir'] + '#egg=docker-registry[bugsnag,newrelic,cors]'
+      'file://' + node['docker-registry']['install_dir'] + '/current#egg=docker-registry[bugsnag,newrelic,cors]'
     ] do
 
       python_pip "#{package}" do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -129,9 +129,6 @@ application "docker-registry" do
   gunicorn do
     only_if { node['docker-registry']['application_server'] }
 
-    packages [
-      '/docker-registry/depends/docker-registry-core'
-    ]
     max_requests node['docker-registry']['max_requests']
     timeout node['docker-registry']['timeout']
     port node['docker-registry']['internal_port']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -42,7 +42,7 @@ if node['docker-registry']['data_bag']
   raise 'Solo mode not supported with "data_bag" attribute' if Chef::Config[:solo]
 
   secrets = Chef::EncryptedDataBagItem.load(node['docker-registry']['data_bag'], node.chef_environment)
-  
+
   if node['roles'].include?('docker-registry_load_balancer') and node['docker-registry']['ssl']
     if secrets["ssl_certificate"] and secrets["ssl_certificate_key"]
 
@@ -129,7 +129,9 @@ application "docker-registry" do
   gunicorn do
     only_if { node['docker-registry']['application_server'] }
 
-    requirements "requirements.txt"
+    packages [
+      '/docker-registry/depends/docker-registry-core'
+    ]
     max_requests node['docker-registry']['max_requests']
     timeout node['docker-registry']['timeout']
     port node['docker-registry']['internal_port']
@@ -142,7 +144,7 @@ application "docker-registry" do
 
   nginx_load_balancer do
     only_if { node['docker-registry']['load_balancer'] }
-    
+
     application_port node['docker-registry']['internal_port']
     application_server_role node['docker-registry']['application_server_role']
     server_name (node['docker-registry']['server_name'] || node['fqdn'] || node['hostname'])

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -126,40 +126,20 @@ application "docker-registry" do
       })
     end
 
-    #docker-registry
-    #boto
-    #redis
-    #setuptools
-    #simplejson
+    for package in [
+      node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
+      'boto',
+      'redis',
+      'setuptools',
+      'simplejson',
+      'gevent'
+    ] do
 
-    python_pip node['docker-registry']['install_dir'] + '/current/docker_registry' do
-      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-      action :upgrade
-    end
+      python_pip "#{package}" do
+        virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+        action :upgrade
+      end
 
-    python_pip 'boto' do
-      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-      action :upgrade
-    end
-
-    python_pip 'redis' do
-      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-      action :upgrade
-    end
-
-    python_pip 'setuptools' do
-      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-      action :upgrade
-    end
-
-    python_pip 'simplejson' do
-      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-      action :upgrade
-    end
-
-    python_pip 'gevent' do
-      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-      action :upgrade
     end
 
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -126,21 +126,17 @@ application "docker-registry" do
       })
     end
 
-    #for package in [
-    #  node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
-    #  'boto',
-    #  'redis',
-    #  'setuptools',
-    #  'simplejson',
-    #  'gevent'
-    #] do
+    for package in [
+      node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
+      node['docker-registry']['install_dir'],
+    ] do
 
-    #  python_pip "#{package}" do
-    #    virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-    #    action :upgrade
-    #  end
+      python_pip "#{package}" do
+        virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+        action :upgrade
+      end
 
-    #end
+    end
 
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -126,21 +126,21 @@ application "docker-registry" do
       })
     end
 
-    for package in [
-      node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
-      'boto',
-      'redis',
-      'setuptools',
-      'simplejson',
-      'gevent'
-    ] do
+    #for package in [
+    #  node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
+    #  'boto',
+    #  'redis',
+    #  'setuptools',
+    #  'simplejson',
+    #  'gevent'
+    #] do
 
-      python_pip "#{package}" do
-        virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
-        action :upgrade
-      end
+    #  python_pip "#{package}" do
+    #    virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+    #    action :upgrade
+    #  end
 
-    end
+    #end
 
   end
 
@@ -153,6 +153,7 @@ application "docker-registry" do
     workers node['docker-registry']['workers']
     worker_class "gevent"
     app_module "wsgi:application"
+    requirements "requirements/main.txt"
     virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
     environment :SETTINGS_FLAVOR => node['docker-registry']['flavor']
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -157,6 +157,11 @@ application "docker-registry" do
       action :upgrade
     end
 
+    python_pip 'gevent' do
+      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+      action :upgrade
+    end
+
   end
 
   gunicorn do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -128,7 +128,7 @@ application "docker-registry" do
 
     for package in [
       node['docker-registry']['install_dir'] + '/current/depends/docker-registry-core',
-      node['docker-registry']['install_dir'],
+      node['docker-registry']['install_dir'] + '/current',
       'file://' + node['docker-registry']['install_dir'] + '/current#egg=docker-registry[bugsnag,newrelic,cors]'
     ] do
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -108,6 +108,7 @@ application "docker-registry" do
   symlinks "config.yml" => "config/config.yml"
 
   before_migrate do
+
     template "#{new_resource.path}/shared/config.yml" do
       source "config.yml.erb"
       mode 0440
@@ -124,6 +125,38 @@ application "docker-registry" do
         :s3_bucket => node['docker-registry']['s3_bucket'],
       })
     end
+
+    #docker-registry
+    #boto
+    #redis
+    #setuptools
+    #simplejson
+
+    python_pip node['docker-registry']['install_dir'] + '/current/docker_registry' do
+      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+      action :upgrade
+    end
+
+    python_pip 'boto' do
+      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+      action :upgrade
+    end
+
+    python_pip 'redis' do
+      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+      action :upgrade
+    end
+
+    python_pip 'setuptools' do
+      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+      action :upgrade
+    end
+
+    python_pip 'simplejson' do
+      virtualenv ::File.join(node['docker-registry']['install_dir'], "env", node['docker-registry']['revision'])
+      action :upgrade
+    end
+
   end
 
   gunicorn do

--- a/templates/default/config.yml.erb
+++ b/templates/default/config.yml.erb
@@ -1,6 +1,6 @@
 # The `common' part is automatically included (and possibly overriden by all
 # other flavors)
-common:
+common: &common
     storage: <%= @storage %>
     storage_path: <%= @storage_path %>
     secret_key: <%= @secret_key %>
@@ -10,7 +10,6 @@ common:
     s3_bucket: <%= @s3_bucket %>
     boto_bucket: <%= @s3_bucket %>
     <% end %>
-
     standalone: <%= @standalone %>
     <% unless @standalone %>
     index_endpoint: <%= @index_endpoint %>
@@ -18,7 +17,9 @@ common:
 
 # This is the default configuration when no flavor is specified
 dev:
+    <<: *common
     loglevel: debug
 
 prod:
+    <<: *common
     loglevel: warn


### PR DESCRIPTION
It seems that a fair bit has changed between versions, and this cookbook no longer worked for newer versions of the registry. This updated cookbook supports registry 0.9.0. I haven't tested other versions.
