### PR TITLE
Added missing libraries for CentOS 7.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,6 +9,7 @@ platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
 #  - name: centos-6.4
+  - name: centos-7.0
 
 suites:
   - name: default

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,8 +59,8 @@ case node['platform']
       default['docker-registry']['packages'] << 'libssl-dev'
       default['docker-registry']['packages'] << 'gcc'
     end
-  when 'centos'
-    default['docker-registry']['packages'] = %w(libevent git libffi)
+  when 'centos','rhel'
+    default['docker-registry']['packages'] = %w(gcc git libevent-devel libffi-devel openssl-devel xz-devel)
   when 'smartos'
     default['docker-registry']['packages'] = %w(libevent scmgit)
 end


### PR DESCRIPTION
- Added CentOS 7.0 as test-kitchen platfrom;
- Added missing libraries for CentOS/RHEL;